### PR TITLE
Fixed food synthesizer not working when player has 0 hunger

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -68,7 +68,7 @@ public class Events implements Listener {
     }
 
     public void checkAndConsume(Player p, FoodLevelChangeEvent e) {
-        FoodSynthesizer foodSynth=(FoodSynthesizer)SlimefunItem.getByID(Items.FOOD_SYNTHESIZER.getItemId());
+        FoodSynthesizer foodSynth = (FoodSynthesizer) Items.FOOD_SYNTHESIZER.getItem();
         for(ItemStack item:p.getInventory().getContents()){
             if(foodSynth.isItem(item)&&foodSynth.removeItemCharge(item,3F)){
                 p.playSound(p.getLocation(),Sound.ENTITY_GENERIC_EAT,1.5F,1F);

--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -15,8 +15,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.ItemStack;
 
-import static dev.j3fftw.litexpansion.Items.FOOD_SYNTHESIZER;
-
 public class Events implements Listener {
 
     @EventHandler
@@ -60,7 +58,7 @@ public class Events implements Listener {
 
     @EventHandler
     public void onHungerDamage(EntityDamageEvent e) {
-        if (FOOD_SYNTHESIZER == null || FOOD_SYNTHESIZER.getItem().isDisabled() || !(e.getEntity() instanceof Player)) {
+        if (Items.FOOD_SYNTHESIZER == null || Items.FOOD_SYNTHESIZER.getItem().isDisabled() || !(e.getEntity() instanceof Player)) {
             return;
         }
 
@@ -70,7 +68,7 @@ public class Events implements Listener {
     }
 
     public void checkAndConsume(Player p, FoodLevelChangeEvent e) {
-        FoodSynthesizer foodSynth=(FoodSynthesizer)SlimefunItem.getByID(FOOD_SYNTHESIZER.getItemId());
+        FoodSynthesizer foodSynth=(FoodSynthesizer)SlimefunItem.getByID(Items.FOOD_SYNTHESIZER.getItemId());
         for(ItemStack item:p.getInventory().getContents()){
             if(foodSynth.isItem(item)&&foodSynth.removeItemCharge(item,3F)){
                 p.playSound(p.getLocation(),Sound.ENTITY_GENERIC_EAT,1.5F,1F);

--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -15,21 +15,15 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.ItemStack;
 
+import static dev.j3fftw.litexpansion.Items.FOOD_SYNTHESIZER;
+
 public class Events implements Listener {
 
     @EventHandler
     public void onHunger(FoodLevelChangeEvent e) {
         Player p = (Player) e.getEntity();
         if (e.getFoodLevel() < p.getFoodLevel()) {
-            FoodSynthesizer foodSynth = (FoodSynthesizer) SlimefunItem.getByID(Items.FOOD_SYNTHESIZER.getItemId());
-            for (ItemStack item : p.getInventory().getContents()) {
-                if (foodSynth.isItem(item) && foodSynth.removeItemCharge(item, 3F)) {
-                    p.playSound(p.getLocation(), Sound.ENTITY_GENERIC_EAT, 1.5F, 1F);
-                    e.setFoodLevel(20);
-                    p.setSaturation(5);
-                    break;
-                }
-            }
+            checkAndConsume(p, e);
         }
     }
 
@@ -60,6 +54,31 @@ public class Events implements Listener {
                 && electricChestplate.removeItemCharge(chestplate, (float) (e.getDamage() / 1.75))
             ) {
                 e.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onHungerDamage(EntityDamageEvent e) {
+        if (FOOD_SYNTHESIZER == null || FOOD_SYNTHESIZER.getItem().isDisabled() || !(e.getEntity() instanceof Player)) {
+            return;
+        }
+
+        if (e.getCause() == EntityDamageEvent.DamageCause.STARVATION) {
+            checkAndConsume((Player) e.getEntity(), null);
+        }
+    }
+
+    public void checkAndConsume(Player p, FoodLevelChangeEvent e) {
+        FoodSynthesizer foodSynth=(FoodSynthesizer)SlimefunItem.getByID(FOOD_SYNTHESIZER.getItemId());
+        for(ItemStack item:p.getInventory().getContents()){
+            if(foodSynth.isItem(item)&&foodSynth.removeItemCharge(item,3F)){
+                p.playSound(p.getLocation(),Sound.ENTITY_GENERIC_EAT,1.5F,1F);
+                p.setFoodLevel(20);
+                p.setSaturation(5);
+                if (e != null) {
+                    e.setFoodLevel(20);
+                }
             }
         }
     }


### PR DESCRIPTION
Players will now get their hunger replenished by the food synth if they have 0 hunger once they take starvation damage.