### PR TITLE
Made solar panels look nicer and easier to understand

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/GlowEnchant.java
+++ b/src/main/java/dev/j3fftw/litexpansion/GlowEnchant.java
@@ -21,7 +21,7 @@ public class GlowEnchant extends Enchantment {
     @Override
     @Deprecated
     public String getName() {
-        return "Glow";
+        return "LX_Glow";
     }
 
     @Override

--- a/src/main/java/dev/j3fftw/litexpansion/Items.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Items.java
@@ -317,8 +317,8 @@ public final class Items {
         "&9Works at Night",
         "",
         LoreBuilderDynamic.powerBuffer(AdvancedSolarPanel.HYBRID_STORAGE),
-        LoreBuilderDynamic.powerPerTick(AdvancedSolarPanel.HYBRID_DAY_RATE) + " (Day)",
-        LoreBuilderDynamic.powerPerTick(AdvancedSolarPanel.HYBRID_NIGHT_RATE) + " (Night)"
+        LoreBuilderDynamic.powerPerTick(AdvancedSolarPanel.HYBRID_DAY_RATE) + " (Day + Nether)",
+        LoreBuilderDynamic.powerPerTick(AdvancedSolarPanel.HYBRID_NIGHT_RATE) + " (Night + End)"
     );
 
     public static final SlimefunItemStack ULTIMATE_SOLAR_PANEL = new SlimefunItemStack(

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -46,11 +46,11 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
 
     private static final int PROGRESS_SLOT = 4;
 
-    private static final CustomItem generatingItem = new CustomItem(Material.GREEN_STAINED_GLASS_PANE,
+    private static final CustomItem generatingItem = new CustomItem(Material.ORANGE_STAINED_GLASS_PANE,
         "&cNot Generating..."
     );
 
-    String time;
+    String generationType;
 
     private final Type type;
 
@@ -76,10 +76,20 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         final boolean canGenerate = stored < getCapacity();
         final int rate = canGenerate ? getGeneratingAmount(inv.getBlock(), l.getWorld()) : 0;
 
+        if (rate == this.type.getDayGenerationRate()) {
+            generationType = "&aOverworld &e(Day)";
+        } if (rate == this.type.getNightGenerationRate()){
+            generationType = "&aOverworld &8(Night)";
+        } if (l.getWorld().getEnvironment() == World.Environment.NETHER){
+            generationType = "&cNether &e(Day)";
+        } if (l.getWorld().getEnvironment() == World.Environment.THE_END){
+            generationType = "&5End &8(Night)";
+        }
+
         if (inv.toInventory() != null && !inv.toInventory().getViewers().isEmpty()) {
             inv.replaceExistingItem(PROGRESS_SLOT,
                 canGenerate ? new CustomItem(Material.GREEN_STAINED_GLASS_PANE, "&aGenerating",
-                    "", "&eTime: " + time,
+                    "", "&bRate: " + generationType,
                     "&7Generating at &6" + Utils.powerFormatAndFadeDecimals(Utils.perTickToPerSecond(rate)) + " J/s &8(" + rate + " J/t)",
                     "", "&7Stored: &6" + (stored + rate) + " J"
                 )
@@ -105,11 +115,8 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         if (world.isThundering() || world.hasStorm() || world.getTime() >= 13000
             || b.getLocation().add(0, 1, 0).getBlock().getLightFromSky() != 15
         ) {
-            time = "&8Night";
             return this.type.getNightGenerationRate();
-        }
-        else {
-            time = "&bDay";
+        } else {
             return this.type.getDayGenerationRate();
         }
     }

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -91,11 +91,11 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
                 canGenerate ? new CustomItem(Material.GREEN_STAINED_GLASS_PANE, "&aGenerating",
                     "", "&bRate: " + generationType,
                     "&7Generating at &6" + Utils.powerFormatAndFadeDecimals(Utils.perTickToPerSecond(rate)) + " J/s &8(" + rate + " J/t)",
-                    "", "&7Stored: &6" + (stored + rate) + " J"
+                    "", "&7Stored: &6" + Utils.powerFormatAndFadeDecimals(stored + rate) + " J"
                 )
                     : new CustomItem(Material.ORANGE_STAINED_GLASS_PANE, "&cNot Generating",
                     "", "&7Generator has reached maximum capacity.",
-                    "", "&7Stored: &6" + stored + " J")
+                    "", "&7Stored: &6" + Utils.powerFormatAndFadeDecimals(stored) + " J")
             );
         }
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -76,14 +76,14 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
 
         String generationType = "&4Unknown";
 
-        if (rate == this.type.getDayGenerationRate()) {
-            generationType = "&aOverworld &e(Day)";
-        } if (rate == this.type.getNightGenerationRate()){
-            generationType = "&aOverworld &8(Night)";
-        } if (l.getWorld().getEnvironment() == World.Environment.NETHER){
+         if (l.getWorld().getEnvironment() == World.Environment.NETHER){
             generationType = "&cNether &e(Day)";
-        } if (l.getWorld().getEnvironment() == World.Environment.THE_END){
+        } else if (l.getWorld().getEnvironment() == World.Environment.THE_END){
             generationType = "&5End &8(Night)";
+        } else if (rate == this.type.getDayGenerationRate()) {
+            generationType = "&aOverworld &e(Day)";
+        } else if (rate == this.type.getNightGenerationRate()){
+            generationType = "&aOverworld &8(Night)";
         }
 
         if (inv.toInventory() != null && !inv.toInventory().getViewers().isEmpty()) {

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -1,6 +1,7 @@
 package dev.j3fftw.litexpansion.machine;
 
 import dev.j3fftw.litexpansion.Items;
+import dev.j3fftw.litexpansion.utils.Utils;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetProvider;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
@@ -49,6 +50,8 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         "&cNot Generating..."
     );
 
+    String time;
+
     private final Type type;
 
     public AdvancedSolarPanel(Type type) {
@@ -76,11 +79,12 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         if (inv.toInventory() != null && !inv.toInventory().getViewers().isEmpty()) {
             inv.replaceExistingItem(PROGRESS_SLOT,
                 canGenerate ? new CustomItem(Material.GREEN_STAINED_GLASS_PANE, "&aGenerating",
-                    "", "&7Generating at &6" + rate + " J",
+                    "", "&eTime: " + time,
+                    "&7Generating at &6" + Utils.powerFormatAndFadeDecimals(Utils.perTickToPerSecond(rate)) + " J/s &8(" + rate + " J/t)",
                     "", "&7Stored: &6" + (stored + rate) + " J"
                 )
-                    : new CustomItem(Material.RED_STAINED_GLASS_PANE, "&cNot Generating",
-                    "", "&7Not generating power, already at maximum capacity.",
+                    : new CustomItem(Material.ORANGE_STAINED_GLASS_PANE, "&cNot Generating",
+                    "", "&7Generator has reached maximum capacity.",
                     "", "&7Stored: &6" + stored + " J")
             );
         }
@@ -100,10 +104,14 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         // Note: You need to get the block above for the light check, the block itself is always 0
         if (world.isThundering() || world.hasStorm() || world.getTime() >= 13000
             || b.getLocation().add(0, 1, 0).getBlock().getLightFromSky() != 15
-        )
+        ) {
+            time = "&8Night";
             return this.type.getNightGenerationRate();
-        else
+        }
+        else {
+            time = "&bDay";
             return this.type.getDayGenerationRate();
+        }
     }
 
     @Override

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -50,8 +50,6 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         "&cNot Generating..."
     );
 
-    String generationType;
-
     private final Type type;
 
     public AdvancedSolarPanel(Type type) {
@@ -75,6 +73,8 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         final int stored = ChargableBlock.getCharge(l);
         final boolean canGenerate = stored < getCapacity();
         final int rate = canGenerate ? getGeneratingAmount(inv.getBlock(), l.getWorld()) : 0;
+
+        String generationType = "&4Unknown";
 
         if (rate == this.type.getDayGenerationRate()) {
             generationType = "&aOverworld &e(Day)";

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Constants.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Constants.java
@@ -1,9 +1,14 @@
 package dev.j3fftw.litexpansion.utils;
 
 import dev.j3fftw.litexpansion.LiteXpansion;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bukkit.NamespacedKey;
 
 public final class Constants {
+
+    public static final int SERVER_TICK_RATE = 20;
+
+    public static final int CUSTOM_TICKER_DELAY = SlimefunPlugin.getCfg().getInt("URID.custom-ticker-delay");
 
     public static final NamespacedKey GLOW_ENCHANT = new NamespacedKey(LiteXpansion.getInstance(),
             "glow_enchant");

--- a/src/main/java/dev/j3fftw/litexpansion/utils/LoreBuilderDynamic.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/LoreBuilderDynamic.java
@@ -17,7 +17,7 @@ public final class LoreBuilderDynamic {
 
 
 
-    public static String powerBuffer(int power) {
+    public static String powerBuffer(double power) {
         return power(power, " Buffer");
     }
 

--- a/src/main/java/dev/j3fftw/litexpansion/utils/LoreBuilderDynamic.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/LoreBuilderDynamic.java
@@ -1,14 +1,8 @@
 package dev.j3fftw.litexpansion.utils;
 
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
-import org.bukkit.ChatColor;
-
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 
 /**
  * This utility class provides a few handy methods and constants to build the lore of any
@@ -21,33 +15,17 @@ import java.util.Locale;
  */
 public final class LoreBuilderDynamic {
 
-    private static final int SERVER_TICK_RATE = 20;
 
-    private static final int CUSTOM_TICKER_DELAY = SlimefunPlugin.getCfg().getInt("URID.custom-ticker-delay");
-
-    private static final DecimalFormat powerFormat = new DecimalFormat("###,###.##", DecimalFormatSymbols.getInstance(Locale.ROOT));
-
-    private static String decimalFade(String str) {
-        if (str.indexOf('.') != -1) {
-            return str.substring(0, str.indexOf('.')) + ChatColor.DARK_GRAY + str.substring(str.indexOf('.')) + ChatColor.GRAY;
-        } else {
-            return str;
-        }
-    }
 
     public static String powerBuffer(int power) {
         return power(power, " Buffer");
     }
 
     public static String powerPerTick(double power) {
-        if (CUSTOM_TICKER_DELAY == 0) {
-            return power( (SERVER_TICK_RATE * power), "/s");
-        } else {
-            return power( (1 / ( (double) CUSTOM_TICKER_DELAY / SERVER_TICK_RATE) * power), "/s");
-        }
+        return power(Utils.perTickToPerSecond(power), "/s");
     }
 
     public static String power(double power, String suffix) {
-        return "&8\u21E8 &e\u26A1 &7" + decimalFade(powerFormat.format(power)) + " J" + suffix;
+        return "&8\u21E8 &e\u26A1 &7" + Utils.powerFormatAndFadeDecimals(power) + " J" + suffix;
     }
 }

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
@@ -44,7 +44,7 @@ public final class Utils {
     }
 
     public static double perTickToPerSecond(double power) {
-        if (Constants.CUSTOM_TICKER_DELAY == 0) {
+        if (Constants.CUSTOM_TICKER_DELAY <= 0) {
             return (Constants.SERVER_TICK_RATE * power);
         } else {
             return (1 / ( (double) Constants.CUSTOM_TICKER_DELAY / Constants.SERVER_TICK_RATE) * power);

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
@@ -3,17 +3,29 @@ package dev.j3fftw.litexpansion.utils;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
 public final class Utils {
 
     private Utils() {}
 
-    public static int euToJ(int i) {
-        return i * 10;
+    private static final DecimalFormat powerFormat = new DecimalFormat("###,###.##", DecimalFormatSymbols.getInstance(Locale.ROOT));
+
+    public static String powerFormatAndFadeDecimals(double power) {
+        String formattedString = powerFormat.format(power);
+        if (formattedString.indexOf('.') != -1) {
+            return formattedString.substring(0, formattedString.indexOf('.')) + ChatColor.DARK_GRAY + formattedString.substring(formattedString.indexOf('.')) + ChatColor.GRAY;
+        } else {
+            return formattedString;
+        }
     }
 
     public static void putOutputSlot(BlockMenuPreset preset, int slot) {
@@ -29,5 +41,13 @@ public final class Utils {
                 return cursor == null || cursor.getType() == Material.AIR;
             }
         });
+    }
+
+    public static double perTickToPerSecond(double power) {
+        if (Constants.CUSTOM_TICKER_DELAY == 0) {
+            return (Constants.SERVER_TICK_RATE * power);
+        } else {
+            return (1 / ( (double) Constants.CUSTOM_TICKER_DELAY / Constants.SERVER_TICK_RATE) * power);
+        }
     }
 }


### PR DESCRIPTION
## Short Description
Moved j/t to j/t methods to Utils and Constants, Added more information to solar panel guis, condensed messages to prevent running off screen.

## Additions/Changes/Removals
- Moved J/t to J/s conversion to Utils (perTickToPerSecond)
- Moved and combined decimal formatting and fading to Utils (powerFormatAndFadeDecimals)
- Moved Minecraft tick rate and Slimefun tick delay to Constants
- Modified solar panel gui to use orange stained glass when full instead of red stained glass to look less like an error
![image](https://user-images.githubusercontent.com/31554056/92059999-48a68900-ed58-11ea-983e-69715fe1ed42.png)
- Modified solar panel gui lore to state if it is day or night
- Modified solar panel gui lore to display both J/s and J/t
![image](https://user-images.githubusercontent.com/31554056/92059671-77702f80-ed57-11ea-8340-c6b5c818dfdc.png)
![image](https://user-images.githubusercontent.com/31554056/92059688-848d1e80-ed57-11ea-8dc9-e60cb2c9226c.png)


## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
Code should be easy to follow, method names are self explanatory
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
Didn't deal with any null values... I think
