### PR TITLE
Fixed SlimyTreeTaps rubber conflict with LX Rubber and added the Wrench

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <version>v1.6.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.TheBusyBiscuit</groupId>
+            <artifactId>SlimyTreeTaps</artifactId>
+            <version>b97239fb3a</version>
+        </dependency>
 
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
+++ b/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
@@ -4,6 +4,7 @@ import dev.j3fftw.litexpansion.items.CargoConfigurator;
 import dev.j3fftw.litexpansion.items.FoodSynthesizer;
 import dev.j3fftw.litexpansion.items.MagThor;
 import dev.j3fftw.litexpansion.items.Thorium;
+import dev.j3fftw.litexpansion.items.Wrench;
 import dev.j3fftw.litexpansion.machine.AdvancedSolarPanel;
 import dev.j3fftw.litexpansion.machine.MassFabricator;
 import dev.j3fftw.litexpansion.machine.ScrapMachine;
@@ -42,6 +43,7 @@ final class ItemSetup {
         registerEndgameItems();
         registerCarbonStuff();
         registerSolarPanels();
+        registerRubber();
     }
 
     private void registerTools() {

--- a/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
+++ b/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
@@ -21,6 +21,8 @@ import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
 
+import static org.bukkit.Bukkit.getServer;
+
 final class ItemSetup {
 
     protected static final ItemSetup INSTANCE = new ItemSetup();
@@ -44,6 +46,7 @@ final class ItemSetup {
 
     private void registerTools() {
         new CargoConfigurator().register(LiteXpansion.getInstance());
+        new Wrench().register(LiteXpansion.getInstance());
     }
 
     private void registerMachines() {
@@ -51,14 +54,19 @@ final class ItemSetup {
 
         new ScrapMachine().register(LiteXpansion.getInstance());
         new MassFabricator().register(LiteXpansion.getInstance());
-        new RubberSynthesizer().register(LiteXpansion.getInstance());
         new RefinedSmeltery().register(LiteXpansion.getInstance());
     }
 
-    private void registerMiscItems() {
-        //Rubber
-        registerNonPlaceableItem(Items.RUBBER, RubberSynthesizer.RECIPE_TYPE, SlimefunItems.OIL_BUCKET);
+    //Disable when SlimyTreeTaps exists
+    private void registerRubber() {
+        if (getServer().getPluginManager().getPlugin("SlimyTreeTaps") == null) {
+            //Rubber
+            registerNonPlaceableItem(Items.RUBBER, RubberSynthesizer.RECIPE_TYPE, SlimefunItems.OIL_BUCKET);
+            new RubberSynthesizer().register(LiteXpansion.getInstance());
+        }
+    }
 
+    private void registerMiscItems() {
         // Advanced Alloy
         registerNonPlaceableItem(Items.ADVANCED_ALLOY, RecipeType.COMPRESSOR, Items.MIXED_METAL_INGOT);
 
@@ -96,9 +104,9 @@ final class ItemSetup {
         );
 
         registerNonPlaceableItem(Items.COPPER_CABLE, RecipeType.ENHANCED_CRAFTING_TABLE,
-            Items.RUBBER, Items.RUBBER, Items.RUBBER,
+            SlimefunItem.getByID("RUBBER").getItem(), SlimefunItem.getByID("RUBBER").getItem(), SlimefunItem.getByID("RUBBER").getItem(),
             Items.UNINSULATED_COPPER_CABLE, Items.UNINSULATED_COPPER_CABLE, Items.UNINSULATED_COPPER_CABLE,
-            Items.RUBBER, Items.RUBBER, Items.RUBBER
+            SlimefunItem.getByID("RUBBER").getItem(), SlimefunItem.getByID("RUBBER").getItem(), SlimefunItem.getByID("RUBBER").getItem(), SlimefunItem.getByID("RUBBER").getItem()
         );
 
         // Circuits

--- a/src/main/java/dev/j3fftw/litexpansion/Items.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Items.java
@@ -59,7 +59,10 @@ public final class Items {
     public static final SlimefunItemStack WRENCH = new SlimefunItemStack(
         "WRENCH",
         Material.GOLDEN_HOE,
-        "&6Wrench"
+        "&6Wrench",
+        "",
+        "&fRight click &cCargo Nodes &fand &aCapacitors",
+        "&fto instantly break them"
     );
 
     public static final SlimefunItemStack TREETAP = new SlimefunItemStack(

--- a/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
@@ -68,7 +68,7 @@ public class Wrench extends SimpleSlimefunItem<ItemUseHandler> implements Listen
                     BlockStorage.clearBlockInfo(interactedBlock);
                     interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), slimefunBlockDrop);
 
-                    if (interactedBlock instanceof InventoryBlock) {
+                    if (BlockStorage.hasInventory(interactedBlock)) {
                         p.sendMessage("This is an inventory block");
                         BlockMenu blockInventory = BlockStorage.getInventory(interactedBlock);
                         int[] inputSlots = ((InventoryBlock) interactedBlock).getInputSlots();

--- a/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
@@ -34,6 +34,9 @@ import static org.bukkit.Bukkit.getLogger;
 
 public class Wrench extends SimpleSlimefunItem<ItemUseHandler> implements Listener {
 
+    protected static final int[] cargoSlots = { 19, 20, 21, 28, 29, 30, 37, 38, 39 };
+    protected static final String[] wrenchableBlockIds = { SlimefunItems.CARGO_INPUT_NODE.getItemId(), SlimefunItems.CARGO_OUTPUT_NODE.getItemId(), SlimefunItems.CARGO_OUTPUT_NODE_2.getItemId(), SlimefunItems.CARGO_CONNECTOR_NODE.getItemId(), SlimefunItems.SMALL_CAPACITOR.getItemId(), SlimefunItems.MEDIUM_CAPACITOR.getItemId(), SlimefunItems.LARGE_CAPACITOR.getItemId(), SlimefunItems.BIG_CAPACITOR.getItemId(), SlimefunItems.CARBONADO_EDGED_CAPACITOR.getItemId(), SlimefunItems.TRASH_CAN.getItemId() };
+
     public Wrench() {
         super(Items.LITEXPANSION, Items.WRENCH, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[] {
                 Items.REFINED_IRON, SlimefunItems.REINFORCED_PLATE, Items.REFINED_IRON,
@@ -54,31 +57,36 @@ public class Wrench extends SimpleSlimefunItem<ItemUseHandler> implements Listen
         Player p = e.getPlayer();
 
         if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            Block interactedBlock = e.getClickedBlock();
-
             if (SlimefunUtils.isItemSimilar(e.getItem(), Items.WRENCH, true, false)) {
                 e.setCancelled(true);
 
-                final SlimefunItem slimefunBlock = BlockStorage.check(e.getClickedBlock());
+                Block interactedBlock = e.getClickedBlock();
+                SlimefunItem slimefunBlock = BlockStorage.check(e.getClickedBlock());
 
-                if (BlockStorage.hasBlockInfo(interactedBlock)) {
+                if (slimefunBlock == null) {
+                    p.sendMessage(ChatColor.RED + "Hey buddy boy this can only be used on cargo nodes and capacitors!");
+                    return;
+                }
 
-                    ItemStack slimefunBlockDrop = slimefunBlock.getItem();
+                for (String wrenchableBlockId : wrenchableBlockIds) {
+                    if (slimefunBlock.getID() == wrenchableBlockId) {
 
-                    BlockStorage.clearBlockInfo(interactedBlock);
-                    interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), slimefunBlockDrop);
+                        ItemStack slimefunBlockDrop = slimefunBlock.getItem();
 
-                    if (BlockStorage.hasInventory(interactedBlock)) {
-                        p.sendMessage("This is an inventory block");
-                        BlockMenu blockInventory = BlockStorage.getInventory(interactedBlock);
-                        int[] inputSlots = ((InventoryBlock) interactedBlock).getInputSlots();
-                        for (int slot : inputSlots) {
-                            p.sendMessage("The input slots are " + slot);
-                            p.sendMessage("The item in this slot is " + blockInventory.getItemInSlot(slot));
-                            interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), blockInventory.getItemInSlot(slot));
+                        BlockStorage.clearBlockInfo(interactedBlock);
+                        interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), slimefunBlockDrop);
+
+                        if (slimefunBlock.getID() == SlimefunItems.CARGO_INPUT_NODE.getItemId() || slimefunBlock.getID() == SlimefunItems.CARGO_OUTPUT_NODE_2.getItemId()) {
+                            for (int slot : cargoSlots) {
+                                ItemStack cargoDrop = BlockStorage.getInventory(interactedBlock).getItemInSlot(slot);
+                                if (cargoDrop != null) {
+                                    interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), cargoDrop);
+                                }
+                            }
+
                         }
+                        interactedBlock.setType(Material.AIR);
                     }
-                    interactedBlock.setType(Material.AIR);
                 }
             }
         }

--- a/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
@@ -1,0 +1,86 @@
+package dev.j3fftw.litexpansion.items;
+
+import dev.j3fftw.litexpansion.Items;
+import dev.j3fftw.litexpansion.LiteXpansion;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.InventoryBlock;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.bukkit.Bukkit.getLogger;
+
+public class Wrench extends SimpleSlimefunItem<ItemUseHandler> implements Listener {
+
+    public Wrench() {
+        super(Items.LITEXPANSION, Items.WRENCH, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[] {
+                Items.REFINED_IRON, SlimefunItems.REINFORCED_PLATE, Items.REFINED_IRON,
+                SlimefunItems.REINFORCED_PLATE, SlimefunItems.ALUMINUM_INGOT, SlimefunItems.REINFORCED_PLATE,
+                Items.REFINED_IRON, SlimefunItems.REINFORCED_PLATE, Items.REFINED_IRON
+        });
+
+        Bukkit.getPluginManager().registerEvents(this, LiteXpansion.getInstance());
+    }
+
+    @Override
+    public ItemUseHandler getItemHandler() {
+        return e -> e.setUseBlock(Event.Result.DENY);
+    }
+
+    @EventHandler
+    public void onWrenchInteract(PlayerInteractEvent e) {
+        Player p = e.getPlayer();
+
+        if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            Block interactedBlock = e.getClickedBlock();
+
+            if (SlimefunUtils.isItemSimilar(e.getItem(), Items.WRENCH, true, false)) {
+                e.setCancelled(true);
+
+                final SlimefunItem slimefunBlock = BlockStorage.check(e.getClickedBlock());
+
+                if (BlockStorage.hasBlockInfo(interactedBlock)) {
+
+                    ItemStack slimefunBlockDrop = slimefunBlock.getItem();
+
+                    BlockStorage.clearBlockInfo(interactedBlock);
+                    interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), slimefunBlockDrop);
+
+                    if (interactedBlock instanceof InventoryBlock) {
+                        p.sendMessage("This is an inventory block");
+                        BlockMenu blockInventory = BlockStorage.getInventory(interactedBlock);
+                        int[] inputSlots = ((InventoryBlock) interactedBlock).getInputSlots();
+                        for (int slot : inputSlots) {
+                            p.sendMessage("The input slots are " + slot);
+                            p.sendMessage("The item in this slot is " + blockInventory.getItemInSlot(slot));
+                            interactedBlock.getLocation().getWorld().dropItemNaturally(interactedBlock.getLocation(), blockInventory.getItemInSlot(slot));
+                        }
+                    }
+                    interactedBlock.setType(Material.AIR);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Short Description
Fixed SlimyTreeTaps rubber conflict with LX Rubber and added the Wrench

## Additions/Changes/Removals
SlimyTreeTaps: Added to POM, LX rubber and Rubber Synthesizer are now disabled when SlimyTreeTaps exists

Wrench: New tool that instantly breaks capacitors and cargo nodes. Drops the inventories of cargo inputs and advanced outputs.

## Related Issues
N?A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
