### PR TITLE
Glass cutter

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/items/GlassCutter.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/GlassCutter.java
@@ -67,7 +67,7 @@ public class GlassCutter extends SimpleSlimefunItem<ItemUseHandler> implements L
 
             final SlimefunItem slimefunItem = BlockStorage.check(block);
             
-            if (slimefunItem != null && removeItemCharge(e.getItem(), 0.5F)) {
+            if (slimefunItem == null && removeItemCharge(e.getItem(), 0.5F)) {
                 blockLocation.getWorld().dropItemNaturally(blockLocation,
                     new ItemStack(blockType));
                 block.setType(Material.AIR);


### PR DESCRIPTION
## Short Description
The glass cutter was not cutting vanilla glass

## Additions/Changes/Removals
I flipped the null check

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
