### PR TITLE
Changed solar panel outputs

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -32,8 +32,8 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
     private static final CustomItem generatingItem = new CustomItem(Material.ORANGE_STAINED_GLASS_PANE,
         "&cNot Generating..."
     );
-    public static int ADVANCED_DAY_RATE = 80;
-    public static int ADVANCED_NIGHT_RATE = 10;
+    public static int ADVANCED_DAY_RATE = 360;
+    public static int ADVANCED_NIGHT_RATE = 45;
     public static int ADVANCED_OUTPUT = 320;
     public static int ADVANCED_STORAGE = 320_000;
     public static int HYBRID_DAY_RATE = 640;
@@ -144,7 +144,7 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         ADVANCED(Items.ADVANCED_SOLAR_PANEL, ADVANCED_DAY_RATE, ADVANCED_NIGHT_RATE, ADVANCED_OUTPUT,
             ADVANCED_STORAGE, new ItemStack[] {
             Items.REINFORCED_GLASS, Items.REINFORCED_GLASS, Items.REINFORCED_GLASS,
-            Items.ADVANCED_ALLOY, SlimefunItems.SOLAR_GENERATOR_3, Items.ADVANCED_ALLOY,
+            Items.ADVANCED_ALLOY, SlimefunItems.SOLAR_GENERATOR_4, Items.ADVANCED_ALLOY,
             SlimefunItems.ADVANCED_CIRCUIT_BOARD, Items.ADVANCED_MACHINE_BLOCK, SlimefunItems.ADVANCED_CIRCUIT_BOARD
         }),
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -32,16 +32,16 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
     private static final CustomItem generatingItem = new CustomItem(Material.ORANGE_STAINED_GLASS_PANE,
         "&cNot Generating..."
     );
-    public static int ADVANCED_DAY_RATE = 80;
-    public static int ADVANCED_NIGHT_RATE = 10;
+    public static int ADVANCED_DAY_RATE = 320;
+    public static int ADVANCED_NIGHT_RATE = 160;
     public static int ADVANCED_OUTPUT = 320;
-    public static int ADVANCED_STORAGE = 320_000;
+    public static int ADVANCED_STORAGE = 100_000;
     public static int HYBRID_DAY_RATE = 640;
-    public static int HYBRID_NIGHT_RATE = 80;
+    public static int HYBRID_NIGHT_RATE = 320;
     public static int HYBRID_OUTPUT = 1200;
     public static int HYBRID_STORAGE = 1_000_000;
     public static int ULTIMATE_DAY_RATE = 5120;
-    public static int ULTIMATE_NIGHT_RATE = 640;
+    public static int ULTIMATE_NIGHT_RATE = 2560;
     public static int ULTIMATE_OUTPUT = 5120;
     public static int ULTIMATE_STORAGE = 10_000_000;
     private final Type type;

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -32,16 +32,16 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
     private static final CustomItem generatingItem = new CustomItem(Material.ORANGE_STAINED_GLASS_PANE,
         "&cNot Generating..."
     );
-    public static int ADVANCED_DAY_RATE = 280;
-    public static int ADVANCED_NIGHT_RATE = 140;
+    public static int ADVANCED_DAY_RATE = 80;
+    public static int ADVANCED_NIGHT_RATE = 10;
     public static int ADVANCED_OUTPUT = 320;
-    public static int ADVANCED_STORAGE = 100_000;
-    public static int HYBRID_DAY_RATE = 560;
-    public static int HYBRID_NIGHT_RATE = 280;
+    public static int ADVANCED_STORAGE = 320_000;
+    public static int HYBRID_DAY_RATE = 640;
+    public static int HYBRID_NIGHT_RATE = 80;
     public static int HYBRID_OUTPUT = 1200;
     public static int HYBRID_STORAGE = 1_000_000;
-    public static int ULTIMATE_DAY_RATE = 4480;
-    public static int ULTIMATE_NIGHT_RATE = 2240;
+    public static int ULTIMATE_DAY_RATE = 5120;
+    public static int ULTIMATE_NIGHT_RATE = 640;
     public static int ULTIMATE_OUTPUT = 5120;
     public static int ULTIMATE_STORAGE = 10_000_000;
     private final Type type;
@@ -144,7 +144,7 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
         ADVANCED(Items.ADVANCED_SOLAR_PANEL, ADVANCED_DAY_RATE, ADVANCED_NIGHT_RATE, ADVANCED_OUTPUT,
             ADVANCED_STORAGE, new ItemStack[] {
             Items.REINFORCED_GLASS, Items.REINFORCED_GLASS, Items.REINFORCED_GLASS,
-            Items.ADVANCED_ALLOY, SlimefunItems.SOLAR_GENERATOR_4, Items.ADVANCED_ALLOY,
+            Items.ADVANCED_ALLOY, SlimefunItems.SOLAR_GENERATOR_3, Items.ADVANCED_ALLOY,
             SlimefunItems.ADVANCED_CIRCUIT_BOARD, Items.ADVANCED_MACHINE_BLOCK, SlimefunItems.ADVANCED_CIRCUIT_BOARD
         }),
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/AdvancedSolarPanel.java
@@ -32,16 +32,16 @@ public class AdvancedSolarPanel extends SlimefunItem implements InventoryBlock, 
     private static final CustomItem generatingItem = new CustomItem(Material.ORANGE_STAINED_GLASS_PANE,
         "&cNot Generating..."
     );
-    public static int ADVANCED_DAY_RATE = 320;
-    public static int ADVANCED_NIGHT_RATE = 160;
+    public static int ADVANCED_DAY_RATE = 280;
+    public static int ADVANCED_NIGHT_RATE = 140;
     public static int ADVANCED_OUTPUT = 320;
     public static int ADVANCED_STORAGE = 100_000;
-    public static int HYBRID_DAY_RATE = 640;
-    public static int HYBRID_NIGHT_RATE = 320;
+    public static int HYBRID_DAY_RATE = 560;
+    public static int HYBRID_NIGHT_RATE = 280;
     public static int HYBRID_OUTPUT = 1200;
     public static int HYBRID_STORAGE = 1_000_000;
-    public static int ULTIMATE_DAY_RATE = 5120;
-    public static int ULTIMATE_NIGHT_RATE = 2560;
+    public static int ULTIMATE_DAY_RATE = 4480;
+    public static int ULTIMATE_NIGHT_RATE = 2240;
     public static int ULTIMATE_OUTPUT = 5120;
     public static int ULTIMATE_STORAGE = 10_000_000;
     private final Type type;


### PR DESCRIPTION
## Short Description
Changed advanced panel power output to be greater than the energized panel it is crafted with.

## Additions/Changes/Removals
Advanced panel daytime rate from 80 to 360, nighttime rate from 10 to 45.

## Related Issues
none

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
