### PR TITLE
Eliminated metal forge confusion

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/Items.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Items.java
@@ -312,7 +312,10 @@ public final class Items {
     public static final SlimefunItemStack METAL_FORGE = new SlimefunItemStack(
         "METAL_FORGE",
         Material.DISPENSER,
-        "&7Metal Forge"
+        "&7Metal Forge",
+        "",
+        "&lUses up the diamond",
+        "block when operated."
     );
 
     private static final Enchantment glowEnchant = Enchantment.getByKey(Constants.GLOW_ENCHANT);

--- a/src/main/java/dev/j3fftw/litexpansion/machine/MetalForge.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/MetalForge.java
@@ -31,7 +31,10 @@ public class MetalForge extends MultiBlockMachine {
         new NamespacedKey(LiteXpansion.getInstance(), "metal_forge"),
         Items.METAL_FORGE,
         "",
-        "&7Used to Forge Metals"
+        "&7Used to Forge Metals",
+        "",
+        "&lUses up the diamond",
+        "block when operating"
     );
 
     private static final ItemStack anvil = new ItemStack(Material.ANVIL);


### PR DESCRIPTION
## Short Description
Added the fact that the diamond block is used up when operating the metal forge to the forge's lore.

## Additions/Changes/Removals
Added 3 lines of lore to metal forge

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.