### PR TITLE
Fixes #74

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -5,6 +5,10 @@ import dev.j3fftw.litexpansion.items.FoodSynthesizer;
 import dev.j3fftw.litexpansion.utils.Constants;
 import dev.j3fftw.litexpansion.weapons.NanoBlade;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.bukkit.Sound;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -68,7 +72,7 @@ public class Events implements Listener {
         }
     }
 
-    public void checkAndConsume(Player p, FoodLevelChangeEvent e) {
+    public void checkAndConsume(@Nonnull Player p, @Nullable FoodLevelChangeEvent e) {
         FoodSynthesizer foodSynth = (FoodSynthesizer) Items.FOOD_SYNTHESIZER.getItem();
         for (ItemStack item : p.getInventory().getContents()) {
             if (foodSynth.isItem(item) && foodSynth.removeItemCharge(item, 5F)) {
@@ -78,6 +82,7 @@ public class Events implements Listener {
                 if (e != null) {
                     e.setFoodLevel(20);
                 }
+                break;
             }
         }
     }

--- a/src/main/java/dev/j3fftw/litexpansion/GlowEnchant.java
+++ b/src/main/java/dev/j3fftw/litexpansion/GlowEnchant.java
@@ -1,20 +1,27 @@
 package dev.j3fftw.litexpansion;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentTarget;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import javax.annotation.Nonnull;
-import java.util.Optional;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
-@SuppressWarnings("NullableProblems")
 public class GlowEnchant extends Enchantment {
 
-    public GlowEnchant(NamespacedKey key) {
+    private final Set<String> ids = new HashSet<>();
+
+    public GlowEnchant(@Nonnull NamespacedKey key, @Nonnull String[] applicableItems) {
         super(key);
+        ids.addAll(Arrays.asList(applicableItems));
     }
 
     @Nonnull
@@ -60,10 +67,9 @@ public class GlowEnchant extends Enchantment {
         if (item.hasItemMeta()) {
             final ItemMeta itemMeta = item.getItemMeta();
             final Optional<String> id = SlimefunPlugin.getItemDataService().getItemData(itemMeta);
+
             if (id.isPresent()) {
-                return (id.get().equals(Items.ADVANCED_CIRCUIT.getItemId()))
-                    || (id.get().equals(Items.NANO_BLADE.getItemId()))
-                    || (id.get().equals(Items.GLASS_CUTTER.getItemId()));
+                return ids.contains(id.get());
             }
         }
         return false;

--- a/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
+++ b/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
 
 final class ItemSetup {
 
-    protected static final ItemSetup INSTANCE = new ItemSetup();
+    static final ItemSetup INSTANCE = new ItemSetup();
     private final ItemStack glass = new ItemStack(Material.GLASS);
     private final SlimefunAddon plugin = LiteXpansion.getInstance();
     private boolean initialised;

--- a/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
+++ b/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
@@ -55,10 +55,10 @@ public class LiteXpansion extends JavaPlugin implements SlimefunAddon {
         } catch (IllegalAccessException | NoSuchFieldException ignored) {
             getLogger().warning("Failed to register enchantment. Seems the 'acceptingNew' field changed monkaS");
         }
-        Enchantment.registerEnchantment(new GlowEnchant(Constants.GLOW_ENCHANT));
 
-        // Category
-        Items.LITEXPANSION.register();
+        Enchantment.registerEnchantment(new GlowEnchant(Constants.GLOW_ENCHANT, new String[] {
+                "ADVANCED_CIRCUIT", "NANO_BLADE", "GLASS_CUTTER"
+        }));
 
         ItemSetup.INSTANCE.init();
 


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
This pull request fixes Issue #74 by adding a break statement after a Food Synthesizer has been located in the inventory, this will also benefit the performance as it reduces unnecessary iterations through the inventory.

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
* Refactored GlowEnchant to use a HashSet
* Added some Nonnull and Nullable annotations
* Removed the registration of the LiteXpansion category (Categories are automatically registered once they have at least one item)

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #74

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
