### PR TITLE
No more wrench message

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -28,18 +28,13 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 
-import dev.j3fftw.litexpansion.armor.ElectricChestplate;
-import dev.j3fftw.litexpansion.items.FoodSynthesizer;
 import dev.j3fftw.litexpansion.items.Wrench;
-import dev.j3fftw.litexpansion.utils.Constants;
 import dev.j3fftw.litexpansion.utils.Utils;
-import dev.j3fftw.litexpansion.weapons.NanoBlade;
 import io.github.thebusybiscuit.slimefun4.implementation.items.cargo.TrashCan;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.InventoryBlock;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.cscorelib2.protection.ProtectableAction;
 
@@ -104,7 +99,7 @@ public class Events implements Listener {
         Block block = e.getBlock();
         Wrench wrench = (Wrench) Items.WRENCH.getItem();
 
-        if (Constants.MACHINE_BREAK_REQUIRES_WRENCH
+        if (Wrench.machineBreakRequiresWrench.getValue()
             && !wrench.isItem(p.getInventory().getItemInMainHand())
             && SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(),
             block.getLocation(), ProtectableAction.BREAK_BLOCK)
@@ -140,10 +135,10 @@ public class Events implements Listener {
 
             if (sfBlock instanceof EnergyNetComponent) {
 
-                if (Constants.MACHINE_BREAK_REQUIRES_WRENCH) {
+                if (Wrench.machineBreakRequiresWrench.getValue()) {
 
                     double random = Math.random();
-                    wrenchBlock(p, block, random <= Constants.WRENCH_FAIL_CHANCE, true);
+                    wrenchBlock(p, block, random <= Wrench.wrenchFailChance.getValue(), true);
 
                 } else {
                     wrenchBlock(p, block, false, true);
@@ -159,7 +154,7 @@ public class Events implements Listener {
                 wrench.damageItem(p, playerWrench);
 
             } else {
-                // Utils.send(p, "&cYou can not use the wrench on this block!");
+                Utils.send(p, "&cYou can not use the wrench on this block!");
             }
         }
     }

--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -159,7 +159,7 @@ public class Events implements Listener {
                 wrench.damageItem(p, playerWrench);
 
             } else {
-                Utils.send(p, "&cYou can not use the wrench on this block!");
+                //Utils.send(p, "&cYou can not use the wrench on this block!");
             }
         }
     }

--- a/src/main/java/dev/j3fftw/litexpansion/Events.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Events.java
@@ -159,7 +159,7 @@ public class Events implements Listener {
                 wrench.damageItem(p, playerWrench);
 
             } else {
-                //Utils.send(p, "&cYou can not use the wrench on this block!");
+                // Utils.send(p, "&cYou can not use the wrench on this block!");
             }
         }
     }

--- a/src/main/java/dev/j3fftw/litexpansion/Items.java
+++ b/src/main/java/dev/j3fftw/litexpansion/Items.java
@@ -1,5 +1,6 @@
 package dev.j3fftw.litexpansion;
 
+import dev.j3fftw.litexpansion.items.Wrench;
 import dev.j3fftw.litexpansion.machine.AdvancedSolarPanel;
 import dev.j3fftw.litexpansion.machine.MassFabricator;
 import dev.j3fftw.litexpansion.machine.RubberSynthesizer;
@@ -17,6 +18,9 @@ import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
 
 public final class Items {
 
@@ -61,8 +65,7 @@ public final class Items {
         "",
         "&7Click any machine, generator, capacitor,",
         "&7or cargo node to instantly break it!",
-        "",
-        "&4Failure Chance: &e" + Utils.wrenchFailureChance() + "%"
+        ""
     );
     public static final SlimefunItemStack GLASS_CUTTER = new SlimefunItemStack(
         "GLASS_CUTTER",
@@ -322,11 +325,6 @@ public final class Items {
     );
 
     private static final Enchantment glowEnchant = Enchantment.getByKey(Constants.GLOW_ENCHANT);
-
-    static {
-        ADVANCED_CIRCUIT.addEnchantment(glowEnchant, 1);
-        GLASS_CUTTER.addEnchantment(glowEnchant, 1);
-    }
 
     private Items() {}
 }

--- a/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
+++ b/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
@@ -1,6 +1,7 @@
 package dev.j3fftw.litexpansion;
 
 import dev.j3fftw.litexpansion.armor.ElectricChestplate;
+import dev.j3fftw.litexpansion.items.Wrench;
 import dev.j3fftw.litexpansion.resources.ThoriumResource;
 import dev.j3fftw.litexpansion.utils.Constants;
 import dev.j3fftw.litexpansion.uumatter.UUMatter;
@@ -37,28 +38,11 @@ public class LiteXpansion extends JavaPlugin implements SlimefunAddon {
         if (!new File(getDataFolder(), "config.yml").exists())
             saveDefaultConfig();
 
-        if (!getConfig().contains("options.need-wrench-to-break-machines")) {
-            getConfig().set("options.need-wrench-to-break-machines", false);
-            saveConfig();
-        }
-
-        if (!getConfig().contains("options.wrench-failure-chance")) {
-            getConfig().set("options.wrench-failure-chance", 0.0);
-            saveConfig();
-        }
-
         final Metrics metrics = new Metrics(this, 7111);
         setupCustomMetrics(metrics);
 
         if (getConfig().getBoolean("options.auto-update") && getDescription().getVersion().startsWith("DEV - ")) {
             new GitHubBuildsUpdater(this, getFile(), "J3fftw1/LiteXpansion/master").start();
-        }
-
-        if (getConfig().getDouble("options.wrench-failure-chance") < 0
-            || getConfig().getDouble("options.wrench-failure-chance") > 1
-        ) {
-            getLogger().log(Level.SEVERE, "The wrench failure chance must be or be between 0 and 1!");
-            getServer().getPluginManager().disablePlugin(this);
         }
 
         getServer().getPluginManager().registerEvents(new Events(), this);
@@ -87,6 +71,13 @@ public class LiteXpansion extends JavaPlugin implements SlimefunAddon {
 
         setupResearches();
         new ThoriumResource().register();
+
+        if (Wrench.wrenchFailChance.getValue() < 0
+            || Wrench.wrenchFailChance.getValue() > 1
+        ) {
+            getLogger().log(Level.SEVERE, "The wrench failure chance must be or be between 0 and 1!");
+            getServer().getPluginManager().disablePlugin(this);
+        }
     }
 
     @Override

--- a/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/Wrench.java
@@ -1,6 +1,7 @@
 package dev.j3fftw.litexpansion.items;
 
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
@@ -23,12 +24,17 @@ import javax.annotation.Nonnull;
  */
 public class Wrench extends SimpleSlimefunItem<ItemUseHandler> implements DamageableItem {
 
+    public static final ItemSetting<Boolean> machineBreakRequiresWrench = new ItemSetting<>("machine-break-requires-wrench", false);
+    public static final ItemSetting<Double> wrenchFailChance = new ItemSetting<>("wrench-failure-chance", 0.0);
+
     public Wrench() {
         super(Items.LITEXPANSION, Items.WRENCH, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[] {
             SlimefunItems.COPPER_INGOT, null, SlimefunItems.COPPER_INGOT,
             null, SlimefunItems.COPPER_INGOT, null,
             null, SlimefunItems.COPPER_INGOT, null
         });
+
+        addItemSetting(machineBreakRequiresWrench, wrenchFailChance);
     }
 
     @Nonnull
@@ -39,5 +45,13 @@ public class Wrench extends SimpleSlimefunItem<ItemUseHandler> implements Damage
     @Override
     public boolean isDamageable() {
         return true;
+    }
+
+    public static String getFailureChance() {
+        if (!Wrench.machineBreakRequiresWrench.getValue()) {
+            return "0";
+        } else {
+            return String.valueOf((Wrench.wrenchFailChance.getValue() * 100));
+        }
     }
 }

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Constants.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Constants.java
@@ -10,10 +10,6 @@ public final class Constants {
 
     public static final int CUSTOM_TICKER_DELAY = SlimefunPlugin.getCfg().getInt("URID.custom-ticker-delay");
 
-    public static final boolean MACHINE_BREAK_REQUIRES_WRENCH = LiteXpansion.getCfg().getBoolean("options.need-wrench-to-break-machines");
-
-    public static final double WRENCH_FAIL_CHANCE = LiteXpansion.getCfg().getDouble("options.wrench-failure-chance");
-
     public static final NamespacedKey GLOW_ENCHANT = new NamespacedKey(LiteXpansion.getInstance(),
         "glow_enchant");
 

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
@@ -1,5 +1,6 @@
 package dev.j3fftw.litexpansion.utils;
 
+import dev.j3fftw.litexpansion.items.Wrench;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
@@ -51,14 +52,6 @@ public final class Utils {
             return (Constants.SERVER_TICK_RATE * power);
         } else {
             return (1 / ((double) Constants.CUSTOM_TICKER_DELAY / Constants.SERVER_TICK_RATE) * power);
-        }
-    }
-
-    public static String wrenchFailureChance() {
-        if (!Constants.MACHINE_BREAK_REQUIRES_WRENCH) {
-            return "0";
-        } else {
-            return String.valueOf((Constants.WRENCH_FAIL_CHANCE * 100));
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,2 @@
 options:
   auto-update: true
-  need-wrench-to-break-machines: true
-  wrench-failure-chance: 0.0


### PR DESCRIPTION
Signed-off-by: NCBPFluffyBear <31554056+ncbpfluffybear@users.noreply.github.com>

## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
I removed the "You can not use the wrench on this block!" message

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
Removed incorrect block message

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
#86 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
