### PR TITLE
Fixed #114

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/items/GlassCutter.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/GlassCutter.java
@@ -6,6 +6,8 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.Rechargeable;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
+import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
+
 import javax.annotation.Nonnull;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -57,11 +59,7 @@ public class GlassCutter extends SimpleSlimefunItem<ItemUseHandler> implements L
         final Location blockLocation = block.getLocation();
 
         if (e.getAction() == Action.LEFT_CLICK_BLOCK
-            && (blockType == Material.GLASS
-            || blockType == Material.GLASS_PANE
-            || blockType.name().endsWith("_GLASS")
-            || blockType.name().endsWith("_GLASS_PANE")
-        ) && isItem(e.getItem())
+            && SlimefunTag.GLASS.isTagged(blockType) && isItem(e.getItem())
             && SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), blockLocation,
             ProtectableAction.BREAK_BLOCK)
         ) {

--- a/src/main/java/dev/j3fftw/litexpansion/items/GlassCutter.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/GlassCutter.java
@@ -7,7 +7,6 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
-
 import javax.annotation.Nonnull;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;

--- a/src/main/java/dev/j3fftw/litexpansion/machine/Generator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/Generator.java
@@ -73,7 +73,7 @@ public class Generator extends CoalGenerator {
         super.registerFuel(new MachineFuel(1, new ItemStack(Material.BAMBOO)));
 
         // Banners
-        for (Material mat : Tag.BANNERS.getValues()) {
+        for (Material mat : Tag.ITEMS_BANNERS.getValues()) {
             registerFuel(new MachineFuel(1, new ItemStack(mat)));
         }
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/ManualMill.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/ManualMill.java
@@ -105,7 +105,7 @@ public class ManualMill extends MultiBlockMachine {
             if (sfItemInv == null && sfItemRecipe == null) {
                 counter++;
             } else if (sfItemInv != null && sfItemRecipe != null
-                && sfItemInv.getID().equals(sfItemRecipe.getID())) {
+                && sfItemInv.getId().equals(sfItemRecipe.getId())) {
                 counter++;
             }
         }


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
This should fix the issue, as "ITEMS_BANNERS" only includes the banner items, whereas the block tag also includes WALL_BANNER items, which do not have an ItemStack form and thus don't render in the Slimefun Guide.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #114

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
