### PR TITLE
Fix Mass Fabricator creating any item

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
@@ -98,9 +98,9 @@ public class MassFabricator extends SlimefunItem implements InventoryBlock, Ener
             return;
         }
 
-        if (!SlimefunUtils.isItemSimilar(input, Items.SCRAP, true))
+        if (!Items.SCRAP.getItem().isItem(input))
             input = null;
-        if (!SlimefunUtils.isItemSimilar(input2, Items.SCRAP, true))
+        if (!Items.SCRAP.getItem().isItem(input2))
             input2 = null;
 
         if (input == null && input2 == null) {

--- a/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
@@ -92,7 +92,9 @@ public class MassFabricator extends SlimefunItem implements InventoryBlock, Ener
         @Nullable ItemStack input = inv.getItemInSlot(INPUT_SLOTS[0]);
         @Nullable ItemStack input2 = inv.getItemInSlot(INPUT_SLOTS[1]);
         @Nullable final ItemStack output = inv.getItemInSlot(OUTPUT_SLOT);
-        if (output != null && output.getAmount() == output.getMaxStackSize()) {
+        if (output != null && (output.getType() != Items.UU_MATTER.getType()
+                || output.getAmount() == output.getMaxStackSize()
+                || !Items.UU_MATTER.getItem().isItem(output))) {
             return;
         }
 


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Added a check to determine if the item in the output slot is UU-Matter before proceeding with the Mass Fabricator's processing. This is to ensure that the Mass Fabricator will not increase the amount of the itemstack in the output slot if it is not a UU-Matter. Changed isItemSimilar to isItem to respect the backwards compatibility setting of Slimefun which can reduce performance cost if it is disabled.

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
- Add a check to determine if the item in the output slot is UU-Matter before proceeding with the Mass Fabricator's processing
- Change isItemSimilar to isItem

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #120 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
