### PR TITLE
Fix for cargo configurator protection bypass problem

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
@@ -51,10 +51,9 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
         return e -> e.setUseBlock(Event.Result.DENY);
     }
 
-    public boolean canUseCargoConfigurator(@Nonnull Player p, @Nonnull Block clicked) {
+    private boolean canUseCargoConfigurator(@Nonnull Player p, @Nonnull Block clicked) {
         return SlimefunPlugin.getProtectionManager().hasPermission(p, clicked, ProtectableAction.ACCESS_INVENTORIES);
     }
-
 
     @EventHandler
     @SuppressWarnings("ConstantConditions")
@@ -64,7 +63,8 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
         }
 
         final ItemStack clickedItem = e.getItem();
-        if (!this.isItem(clickedItem)) {
+
+        if (!this.isItem(clickedItem) || SlimefunItem.getByItem(Items.CARGO_CONFIGURATOR).isDisabled()) {
             return;
         }
 
@@ -103,11 +103,8 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
             return;
         }
 
-        if (SlimefunItem.getByItem(Items.CARGO_CONFIGURATOR).isDisabled()) {
-            return;
-        }
+        final Player p = e.getPlayer();
 
-        Player p = e.getPlayer();
         if (!canUseCargoConfigurator(p, e.getClickedBlock()) && !p.hasPermission("slimefun.cargo.bypass")) {
             SlimefunPlugin.getLocalization().sendMessage(p, "inventory.no-access", true);
             return;

--- a/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
@@ -2,9 +2,7 @@ package dev.j3fftw.litexpansion.items;
 
 import dev.j3fftw.litexpansion.Items;
 import dev.j3fftw.litexpansion.LiteXpansion;
-import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
-import io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
@@ -13,21 +11,12 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
-import me.mrCookieSlime.CSCoreLibPlugin.protection.ProtectionManager;
-import me.mrCookieSlime.CSCoreLibPlugin.protection.ProtectionModule;
-import me.mrCookieSlime.CSCoreLibPlugin.protection.modules.GriefPreventionProtectionModule;
-import me.mrCookieSlime.CSCoreLibPlugin.protection.modules.PlotSquaredProtectionModule;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
-import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.cscorelib2.data.PersistentDataAPI;
 import me.mrCookieSlime.Slimefun.cscorelib2.protection.ProtectableAction;
-import me.mrCookieSlime.Slimefun.cscorelib2.protection.modules.PlotSquared5ProtectionModule;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -45,7 +34,6 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
 
     private static final NamespacedKey CARGO_BLOCK = new NamespacedKey(LiteXpansion.getInstance(), "cargo_block");
     private static final NamespacedKey CARGO_CONFIG = new NamespacedKey(LiteXpansion.getInstance(), "cargo_config");
-    private Config local = new Config("plugins/CS-CoreLib/protection.yml");
 
     public CargoConfigurator() {
         super(Items.LITEXPANSION, Items.CARGO_CONFIGURATOR, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[] {

--- a/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
@@ -2,17 +2,32 @@ package dev.j3fftw.litexpansion.items;
 
 import dev.j3fftw.litexpansion.Items;
 import dev.j3fftw.litexpansion.LiteXpansion;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
+import io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
+
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
+import me.mrCookieSlime.CSCoreLibPlugin.protection.ProtectionManager;
+import me.mrCookieSlime.CSCoreLibPlugin.protection.ProtectionModule;
+import me.mrCookieSlime.CSCoreLibPlugin.protection.modules.GriefPreventionProtectionModule;
+import me.mrCookieSlime.CSCoreLibPlugin.protection.modules.PlotSquaredProtectionModule;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.Slimefun;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.cscorelib2.data.PersistentDataAPI;
+import me.mrCookieSlime.Slimefun.cscorelib2.protection.ProtectableAction;
+import me.mrCookieSlime.Slimefun.cscorelib2.protection.modules.PlotSquared5ProtectionModule;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -30,6 +45,7 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
 
     private static final NamespacedKey CARGO_BLOCK = new NamespacedKey(LiteXpansion.getInstance(), "cargo_block");
     private static final NamespacedKey CARGO_CONFIG = new NamespacedKey(LiteXpansion.getInstance(), "cargo_config");
+    private Config local = new Config("plugins/CS-CoreLib/protection.yml");
 
     public CargoConfigurator() {
         super(Items.LITEXPANSION, Items.CARGO_CONFIGURATOR, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[] {
@@ -45,6 +61,10 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
     @Override
     public ItemUseHandler getItemHandler() {
         return e -> e.setUseBlock(Event.Result.DENY);
+    }
+
+    public boolean canUseCargoConfigurator(@Nonnull PlayerInteractEvent e) {
+        return SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), e.getClickedBlock(), ProtectableAction.ACCESS_INVENTORIES);
     }
 
     @EventHandler
@@ -91,6 +111,15 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
             && !blockId.equals(SlimefunItems.CARGO_OUTPUT_NODE.getItemId())
             && !blockId.equals(SlimefunItems.CARGO_OUTPUT_NODE_2.getItemId())
         ) {
+            return;
+        }
+
+        if(SlimefunItem.getByItem(Items.CARGO_CONFIGURATOR).isDisabled()) {
+            return;
+        }
+
+        if (!canUseCargoConfigurator(e) && !e.getPlayer().hasPermission("slimefun.cargo.bypass")) {
+            e.getPlayer().sendMessage(ChatColor.RED + "You don't have permission to use this tool in this area.");
             return;
         }
 

--- a/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/items/CargoConfigurator.java
@@ -6,12 +6,6 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import javax.annotation.Nonnull;
-
-import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -21,6 +15,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -29,6 +24,11 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implements Listener {
 
@@ -51,9 +51,10 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
         return e -> e.setUseBlock(Event.Result.DENY);
     }
 
-    public boolean canUseCargoConfigurator(@Nonnull PlayerInteractEvent e) {
-        return SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), e.getClickedBlock(), ProtectableAction.ACCESS_INVENTORIES);
+    public boolean canUseCargoConfigurator(@Nonnull Player p, @Nonnull Block clicked) {
+        return SlimefunPlugin.getProtectionManager().hasPermission(p, clicked, ProtectableAction.ACCESS_INVENTORIES);
     }
+
 
     @EventHandler
     @SuppressWarnings("ConstantConditions")
@@ -102,12 +103,13 @@ public class CargoConfigurator extends SimpleSlimefunItem<ItemUseHandler> implem
             return;
         }
 
-        if(SlimefunItem.getByItem(Items.CARGO_CONFIGURATOR).isDisabled()) {
+        if (SlimefunItem.getByItem(Items.CARGO_CONFIGURATOR).isDisabled()) {
             return;
         }
 
-        if (!canUseCargoConfigurator(e) && !e.getPlayer().hasPermission("slimefun.cargo.bypass")) {
-            e.getPlayer().sendMessage(ChatColor.RED + "You don't have permission to use this tool in this area.");
+        Player p = e.getPlayer();
+        if (!canUseCargoConfigurator(p, e.getClickedBlock()) && !p.hasPermission("slimefun.cargo.bypass")) {
+            SlimefunPlugin.getLocalization().sendMessage(p, "inventory.no-access", true);
             return;
         }
 


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
I just added few lines to the CargoConfigurator class which checks the player building priveleges every time when iteract with the CargoConfigurator tool. I also added a small fix for a problem when the tool is disabled in the slimefun items config the player still can use it.

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
Added CS-CoreLib checker to make sure the tools is enabled on the server
Added ProtectionManager from the SlimeFun library
Added CS-CoreLib localization when the user doesn't have permission to modify the cargo settings.
I added **slimefun.cargo.bypass** permission as a cargo configurator protection bypass permission. So if somebody has this perm he can bypass the protection.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #117

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
